### PR TITLE
Fix misspelling of "Connection Failed" message

### DIFF
--- a/src/client/app/pages/editor/components/monaco/monaco.component.ts
+++ b/src/client/app/pages/editor/components/monaco/monaco.component.ts
@@ -177,7 +177,7 @@ export class MonacoComponent implements AfterViewInit {
             .catch((error: DOMException) => {
                 this.tab.connectionStatus = OPERATION_STATUS.NOT_STARTED;
                 this.onError.emit({
-                    header: 'Conneciton failed',
+                    header: 'Connection failed',
                     body: error.message
                 });
             });


### PR DESCRIPTION
If there's no board connected and you try to connect you get an error message in a red box with a misspelling.

![image](https://cloud.githubusercontent.com/assets/11063618/24982866/9200712e-1f98-11e7-8f96-3c931dfe533f.png)
