### PR TITLE
Fix misspelling of GitHub on sidebar

### DIFF
--- a/src/client/app/pages/editor/components/sidebar-github/sidebar-github.component.html
+++ b/src/client/app/pages/editor/components/sidebar-github/sidebar-github.component.html
@@ -24,7 +24,7 @@
               [(ngModel)]="gitHubService.data.user.token"/>
 
         <span id="token-help-block" class="help-block">
-            You can get your Gitub API token
+            You can get your GitHub API token
             <a target="_blank" href="https://github.com/settings/tokens">
                 here
             </a>.


### PR DESCRIPTION
fix: misspelling of GitHub on sidebar

Closes #113