### PR TITLE
console: print console messages in separate lines

### DIFF
--- a/src/client/app/shared/webusb/webusb.port.ts
+++ b/src/client/app/shared/webusb/webusb.port.ts
@@ -40,6 +40,7 @@ export class WebUsbPort {
                         skip_prompt = true,
                         str = this.decoder.decode(result.data);
 
+
                     if (str === 'raw') {
                         this.rawMode = true;
                         str = '';
@@ -67,12 +68,14 @@ export class WebUsbPort {
                             this.previousRead !== undefined &&
                             this.previousRead.charCodeAt(
                                 this.previousRead.length - 1) === 13) {
-                            str = '\n' + str;
+                            str = '\r\n' + str;
                         }
 
-                        this.previousRead = str;
                         this.onReceive(str);
                     }
+
+                    if (!skip)
+                        this.previousRead = str;
 
                     if (this.device.opened) {
                         readLoop();


### PR DESCRIPTION
We are skipping all unintended empty newlines to make the console
output clean and that is causing an issue of printing all the
messages in a single line. This patch fixes the issue by adding
a new line \r\n between the messages.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>