### PR TITLE
fix(webusb): fix urls treated as comments and stripped

### DIFF
--- a/src/client/app/shared/webusb/webusb.port.ts
+++ b/src/client/app/shared/webusb/webusb.port.ts
@@ -234,7 +234,7 @@ export class WebUsbPort {
     }
 
     private stripComments(source: string): string {
-      return source.replace(RegExp('[ \t]*//.*', 'g'), '');
+      return source.replace(RegExp('^[ \t]{0,}//.*', 'g'), '');
     }
 
     private stripBlankLines(source: string): string {


### PR DESCRIPTION
Fix the regex to only strip comments starting with blank spaces

Closes #143

Signed-off-by: Jimmy Huang <jimmy.huang@intel.com>