### PR TITLE
fix(editor): Enable "Run" only after ashell is ready

### DIFF
--- a/src/client/app/pages/editor/components/device-toolbar/device-toolbar.component.ts
+++ b/src/client/app/pages/editor/components/device-toolbar/device-toolbar.component.ts
@@ -108,7 +108,8 @@ export class DeviceToolbarComponent implements AfterViewInit {
                tab.editor !== null &&
                tab.editor.getValue().length > 0 &&
                tab.runStatus !== OPERATION_STATUS.IN_PROGRESS &&
-               this.webusbService.isConnected();
+               this.webusbService.isConnected() &&
+               this.webusbService.isAshellReady();
     }
 
     // tslint:disable-next-line:no-unused-locals

--- a/src/client/app/shared/webusb/webusb.port.ts
+++ b/src/client/app/shared/webusb/webusb.port.ts
@@ -14,6 +14,7 @@ export class WebUsbPort {
     rawMode: boolean;
     echoMode: boolean;
     previousRead: string;
+    ashellReady: boolean;
 
     constructor(device: any) {
         this.device = device;
@@ -32,6 +33,7 @@ export class WebUsbPort {
     public connect(): Promise<void> {
         this.rawMode = true;
         this.echoMode = true;
+        this.ashellReady = false;
 
         return new Promise<void>((resolve, reject) => {
             let readLoop = () => {
@@ -39,6 +41,9 @@ export class WebUsbPort {
                     let skip = true,
                         skip_prompt = true,
                         str = this.decoder.decode(result.data);
+
+                    if (!this.ashellReady)
+                        this.ashellReady = /^(\x1b\[33macm)/.test(str);
 
                     if (str === 'raw') {
                         this.rawMode = true;
@@ -147,6 +152,10 @@ export class WebUsbPort {
 
     public isConnected(): boolean {
         return this.device && this.device.opened;
+    }
+
+    public isAshellReady(): boolean {
+        return this.ashellReady;
     }
 
     public read(): Promise<string> {

--- a/src/client/app/shared/webusb/webusb.service.ts
+++ b/src/client/app/shared/webusb/webusb.service.ts
@@ -93,6 +93,10 @@ export class WebUsbService {
         return this.port !== null && this.port.isConnected();
     }
 
+    public isAshellReady(): boolean {
+        return this.port.isAshellReady();
+    }
+
     public send(data: string) {
         return this.port.send(data);
     }


### PR DESCRIPTION
Transfer was failing if we send data before the ashell
is ready, so this patch fixes the issue by enabling
'Run' button only after 'acm>' prompt is received from
the ashell.

Signed-off-by: Sudarsana Nagineni <sudarsana.nagineni@intel.com>