### PR TITLE
fix(websub): Add delay in the 'Save to device' transfer loop

### DIFF
--- a/src/client/app/shared/webusb/webusb.port.spec.ts
+++ b/src/client/app/shared/webusb/webusb.port.spec.ts
@@ -213,7 +213,7 @@ export function main() {
 
         it('save should work', done => {
             port.connect().then(() => {
-                port.save('foo.txt', 'foo').then((result: string) => {
+                port.save('foo.txt', 'foo', true).then((result: string) => {
                     expect(result).toBe(undefined); // no warning
                     done();
                 });

--- a/src/client/app/shared/webusb/webusb.service.ts
+++ b/src/client/app/shared/webusb/webusb.service.ts
@@ -123,6 +123,7 @@ export class WebUsbService {
             });
         }
 
-        return this.port.save(filename, data);
+        let throttle = this.settingsService.getDeviceThrottle();
+        return this.port.save(filename, data, throttle);
     }
 }


### PR DESCRIPTION
Add delay in the 'Save to device' transfer loop to prevent the UART from overflowing.